### PR TITLE
varnish: services fix for puppet 2.7 compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,17 +11,19 @@ class varnish {
   package { "varnish": ensure => present }
 
   service { "varnish":
-    enable  => false,
-    ensure  => "stopped",
-    pattern => "/var/run/varnishd.pid",
-    require => Package["varnish"],
+    enable    => false,
+    ensure    => "stopped",
+    pattern   => "/var/run/varnishd.pid",
+    hasstatus => false,
+    require   => Package["varnish"],
   }
 
   service { "varnishlog":
-    enable  => false,
-    ensure  => "stopped",
-    pattern => "/var/run/varnishlog.pid",
-    require => Package["varnish"],
+    enable    => false,
+    ensure    => "stopped",
+    pattern   => "/var/run/varnishlog.pid",
+    hasstatus => false,
+    require   => Package["varnish"],
   }
 
   file { "/usr/local/sbin/vcl-reload.sh":

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -156,9 +156,11 @@ define varnish::instance($address=[":80"],
   if ($varnishlog == true ) {
 
     service { "varnishlog-${instance}":
-      enable  => true,
-      ensure  => running,
-      require => [
+      enable    => true,
+      ensure    => running,
+      pattern   => "/var/run/varnishlog-${instance}.pid",
+      hasstatus => false,
+      require   => [
         File["/etc/init.d/varnishlog-${instance}"],
         Service["varnish-${instance}"],
       ],
@@ -167,9 +169,11 @@ define varnish::instance($address=[":80"],
   } else {
 
     service { "varnishlog-${instance}":
-      enable  => false,
-      ensure  => stopped,
-      require => File["/etc/init.d/varnishlog-${instance}"],
+      enable    => false,
+      ensure    => stopped,
+      pattern   => "/var/run/varnishlog-${instance}.pid",
+      hasstatus => false,
+      require   => File["/etc/init.d/varnishlog-${instance}"],
     }
   }
 


### PR DESCRIPTION
Puppet 2.7 defaults hasstatus to true. Varnishes status commands don't seems
to work well. Using patterns in services seems more reliable.
