### PR TITLE
The location of the nagios plugin source has changed.

### DIFF
--- a/manifests/nagiosplugin.pp
+++ b/manifests/nagiosplugin.pp
@@ -26,38 +26,38 @@ class varnish::nagiosplugin {
     $nagios_plugin_dir = "/usr/lib/nagios/plugins/contrib"
   }
 
-  $baseurl = "https://www.varnish-cache.org/svn/"
+  $baseurl = 'https://github.com/varnish/varnish-nagios'
 
   case $varnish_version {
     "2.1.1", "2.1.2": {
       # http://www.varnish-cache.org/trac/ticket/710
-      $rev = "4009"
-      $branch = "tags/varnish-${varnish_version}"
+      $revision = '70e4ded1221846d4149dd743e2ac634946c313ad'
+      $branch   = 'master'
       $buildopt = ""
     }
     "2.1.3": {
-      $rev = "4009"
-      $branch = "branches/2.1"
+      $revision = '70e4ded1221846d4149dd743e2ac634946c313ad'
+      $branch   = 'master'
       $buildopt = "VARNISHAPI_LIBS='-lvarnishapi -lvarnish -lvarnishcompat'"
     }
     /^2\.0\./: {
-      $rev = "5773"
-      $branch = "branches/2.0"
+      $revision = 'a64abfb7e70fd1f6b53ff64f9ddeafb7209c0b23'
+      $branch   = 'master'
       $buildopt = ""
     }
     default: {
-      $rev = "HEAD"
-      $branch = "trunk"
+      $revision = 'HEAD'
+      $branch   = 'master'
       $buildopt = ""
     }
   }
 
-  $workdir = "/usr/src/check_varnish-${varnish_version}-${rev}"
+  $workdir = "/usr/src/check_varnish-${varnish_version}-${revision}"
 
   vcsrepo { $workdir:
-    provider => "svn",
-    source   => "${baseurl}${branch}/varnish-tools/nagios/",
-    revision => $rev,
+    provider => 'git',
+    source   => "${baseurl}/",
+    revision => "$revision",
   }
 
   file { "${workdir}/build-plugin.sh":


### PR DESCRIPTION
Now on github, in another repo than the varnish sources.
2.1: the commit 70e4ded1221846d4149dd743e2ac634946c313ad has the svn tag 4009
2.0: the commit a64abfb7e70fd1f6b53ff64f9ddeafb7209c0b23 is the last one were the MAC_STAT macro has 4 arguments.

Sources for varnish are now here:
https://github.com/varnish/Varnish-Cache

and nagios plugin:
https://github.com/varnish/varnish-nagios

I tried to be as close as possible from the old svn (vanished) configuration.
