### PR TITLE
varnish vcl-reload: add support for secret file

### DIFF
--- a/files/usr/local/sbin/vcl-reload.sh
+++ b/files/usr/local/sbin/vcl-reload.sh
@@ -4,12 +4,15 @@
 
 # Original version: http://kristian.blog.linpro.no/2009/02/18/easy-reloading-of-varnish-vcl/
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 vcl_file"
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 vcl_file [secret_file]"
   exit 1
 fi
-
 FILE=$1
+
+if [ $# -ge 2 ]; then
+  SECRET_OPT="-S $2"
+fi
 
 # Hostname and management port
 # (defined in /etc/default/varnish or on startup)
@@ -26,15 +29,15 @@ error()
 echo "@@@ Checking VCL file syntax:"
 varnishd -d -s malloc -n "$TMPDIR" -f $FILE < /dev/null || error
 
-rm -f "$TMPDIR/_.vsl" && rmdir "$TMPDIR"
+rm -f "$TMPDIR/_.vsm" && rmdir "$TMPDIR"
 
 echo -e "\n@@@ Loading new VCL file:"
-varnishadm -T $HOSTPORT vcl.load reload$NOW $FILE || error
-varnishadm -T $HOSTPORT vcl.use reload$NOW || error
+varnishadm $SECRET_OPT -T $HOSTPORT vcl.load reload$NOW $FILE || error
+varnishadm $SECRET_OPT -T $HOSTPORT vcl.use reload$NOW || error
 
 
 echo -e "\n@@@ Currently available VCL configs:"
-varnishadm -T $HOSTPORT vcl.list
+varnishadm $SECRET_OPT -T $HOSTPORT vcl.list
 
 exit 0
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -147,7 +147,10 @@ define varnish::instance($address=[":80"],
     ensure  => running,
     pattern => "/var/run/varnish-${instance}.pid",
     # reload VCL file when changed, without restarting the varnish service.
-    restart => "/usr/local/sbin/vcl-reload.sh /etc/varnish/${instance}.vcl",
+    restart => $enable_secret ? {
+      false => "/usr/local/sbin/vcl-reload.sh /etc/varnish/${instance}.vcl",
+      true  => "/usr/local/sbin/vcl-reload.sh /etc/varnish/${instance}.vcl ${secret_file}",
+    },
     require => [
       File["/etc/init.d/varnish-${instance}"],
       File["/usr/local/sbin/vcl-reload.sh"],


### PR DESCRIPTION
vcl-reload.sh gains an option to pass a secret file, which it passes
to the varnishadm command.
